### PR TITLE
Pdc 47 single blog view

### DIFF
--- a/backend/src/server/blogs/get/getAllBlogPosts.ts
+++ b/backend/src/server/blogs/get/getAllBlogPosts.ts
@@ -6,6 +6,7 @@ const router = Router();
 router.get("/get-all-blog-posts", async (req, res) => {
   try {
     const allExistingBlogs = await prisma.blog.findMany({
+      orderBy: { createdAt: "desc" },
       select: {
         id: true,
         title: true,

--- a/backend/src/server/blogs/get/getSingleBlogPost.ts
+++ b/backend/src/server/blogs/get/getSingleBlogPost.ts
@@ -13,9 +13,7 @@ router.get("/get-single-blog-post/:blogId", async (req, res) => {
     if (!existingBlog) {
       return res.status(404).json({ message: "Blog post no encontrado" });
     }
-    return res
-      .status(200)
-      .json({ existingBlog, message: "Blog post necontrado" });
+    return res.status(200).json(existingBlog);
   } catch (error) {
     if (error instanceof Error) {
       return res.status(500).json({

--- a/frontend/src/app/(un-auth-regular-user)/blogs/all-blogs/blog/[blogId]/page.tsx
+++ b/frontend/src/app/(un-auth-regular-user)/blogs/all-blogs/blog/[blogId]/page.tsx
@@ -1,7 +1,11 @@
-export default function BlogPage() {
+import { SingleBlog } from "@/blogs/blog/singleBlog";
+
+export default function BlogPage({ params }: { params: { blogId: string } }) {
+  const blogId = parseInt(params.blogId);
+
   return (
-    <div>
-      <h1>Hello Page</h1>
-    </div>
+    <section className="flex flex-col items-center justify-center px-4">
+      <SingleBlog blogId={blogId} />
+    </section>
   );
 }

--- a/frontend/src/app/(un-auth-regular-user)/blogs/all-blogs/page.tsx
+++ b/frontend/src/app/(un-auth-regular-user)/blogs/all-blogs/page.tsx
@@ -2,8 +2,8 @@ import AllBlogsComponent from "@/blogs/components/AllBlogsComponent";
 
 export default function BlogsPage() {
   return (
-    <div className="flex flex-col items-center justify-center px-4">
+    <section className="flex flex-col items-center justify-center px-4">
       <AllBlogsComponent />
-    </div>
+    </section>
   );
 }

--- a/frontend/src/blogs/blog/singleBlog.tsx
+++ b/frontend/src/blogs/blog/singleBlog.tsx
@@ -1,0 +1,32 @@
+"use client";
+import { BookLoaderComponent } from "@/components/shared/BookLoader";
+import { fetchSingleBlog } from "@/store/slices/blogs/thunks/fetchSingleBlog";
+import { AppDispatch, RootState } from "@/store/store";
+import React, { useEffect } from "react";
+import { useDispatch, useSelector } from "react-redux";
+import { SingleBlogComponent } from "../components/SingleBlogComponent";
+
+export const SingleBlog = ({ blogId }: { blogId: number }) => {
+  const dispatch = useDispatch<AppDispatch>();
+  const {
+    data: blog,
+    loading,
+    error,
+  } = useSelector((state: RootState) => state.SingleBlog);
+
+  useEffect(() => {
+    if (!blog || blog.id !== blogId) {
+      dispatch(fetchSingleBlog(blogId));
+    }
+  }, [blogId, dispatch]);
+
+  if (loading) {
+    return <BookLoaderComponent />;
+  }
+  if (error) {
+    return <div>{error}</div>;
+  }
+  if (blog) {
+    return <SingleBlogComponent {...blog} />;
+  }
+};

--- a/frontend/src/blogs/components/SingleBlogComponent.tsx
+++ b/frontend/src/blogs/components/SingleBlogComponent.tsx
@@ -28,7 +28,9 @@ export const SingleBlogComponent = ({
       </section>
 
       <section className="mt-2 bg-cardsBackground rounded-lg">
-        <p className="text-mainText p-2 break-words">{blogText}</p>
+        <p className="text-mainText p-2 break-words whitespace-pre-wrap">
+          {blogText}
+        </p>
       </section>
     </article>
   );

--- a/frontend/src/blogs/components/SingleBlogComponent.tsx
+++ b/frontend/src/blogs/components/SingleBlogComponent.tsx
@@ -1,0 +1,35 @@
+import React from "react";
+
+import { ImageComponent } from "@/components/shared/ImageComponent";
+import { SingleBlog } from "../interface/blogs";
+
+export const SingleBlogComponent = ({
+  id,
+  title,
+  imagen,
+  createdAt,
+  blogText,
+  estimatedReadTime,
+}: SingleBlog) => {
+  return (
+    <article className="flex flex-col w-full px-4 max-w-screen-xl">
+      <h1 className="text-encabezados text-2xl self-start mt-2">
+        Noticias & Pensamientos
+      </h1>
+      <section className="flex flex-col items-center gap-4 mt-4">
+        <div>
+          <ImageComponent imagen={imagen} title={title} />
+        </div>
+        <h2 className="text-encabezados text-2xl">{title}</h2>
+        <p className="text-mainText/50 text-sm">GPS</p>
+        <span className="text-mainText/50 text-sm">
+          {createdAt} · {estimatedReadTime}
+        </span>
+      </section>
+
+      <section className="mt-2 bg-cardsBackground rounded-lg">
+        <p className="text-mainText p-2 break-words">{blogText}</p>
+      </section>
+    </article>
+  );
+};

--- a/frontend/src/blogs/interface/blogs.d.ts
+++ b/frontend/src/blogs/interface/blogs.d.ts
@@ -1,8 +1,18 @@
+import { SingleBlog } from "../blog/singleBlog";
 export type Blogs = AllExistingBlog[];
 
 export interface AllExistingBlog {
   id: number;
   title: string;
+  imagen: string;
+  createdAt: string;
+  estimatedReadTime: string;
+}
+
+export interface SingleBlog {
+  id: number;
+  title: string;
+  blogText: string;
   imagen: string;
   createdAt: string;
   estimatedReadTime: string;

--- a/frontend/src/blogs/utils/getSingleBlog.ts
+++ b/frontend/src/blogs/utils/getSingleBlog.ts
@@ -1,0 +1,20 @@
+import type { SingleBlog } from "../interface/blogs";
+
+export const getSingleBlog = async (blogId: number): Promise<SingleBlog> => {
+  try {
+    const response = await fetch(
+      `${process.env.NEXT_PUBLIC_BACKEND_URL}/blog/get-single-blog-post/${blogId}`
+    );
+    const data = await response.json();
+    const estimatedReadTimeToString = {
+      ...data,
+      createdAt: new Date(data.createdAt).toLocaleDateString(),
+    };
+    return estimatedReadTimeToString;
+  } catch (error) {
+    if (error instanceof Error) {
+      throw new Error(error.message);
+    }
+    throw new Error("Error inesperado");
+  }
+};

--- a/frontend/src/homepage/blogs/blogCard.tsx
+++ b/frontend/src/homepage/blogs/blogCard.tsx
@@ -21,7 +21,7 @@ const BlogCard = ({
 
       <div className=" flex flex-col items-center mt-10">
         <h2 className="text-encabezados mb-6 text-xl">{title}</h2>
-        <MainButton name="Leer" link={`/blogs/blog/${id}`} />
+        <MainButton name="Leer" link={`/blogs/all-blogs/blog/${id}`} />
       </div>
       <div className=" text-mainText opacity-50 text-sm self-end p-2">
         <p>

--- a/frontend/src/store/slices/blogs/singleBlogSlice.ts
+++ b/frontend/src/store/slices/blogs/singleBlogSlice.ts
@@ -1,0 +1,34 @@
+import { createSlice } from "@reduxjs/toolkit";
+import { fetchSingleBlog } from "./thunks/fetchSingleBlog";
+import type { SingleBlog } from "@/blogs/interface/blogs";
+
+const initialState: {
+  data: SingleBlog | null;
+  loading: boolean;
+  error: string | null;
+} = {
+  data: null,
+  loading: false,
+  error: null,
+};
+const singleBlogSlice = createSlice({
+  name: "SingleBlog",
+  initialState,
+  reducers: {},
+  extraReducers: (builder) => {
+    builder
+      .addCase(fetchSingleBlog.fulfilled, (state, action) => {
+        state.loading = false;
+        state.data = action.payload;
+      })
+      .addCase(fetchSingleBlog.pending, (state) => {
+        state.loading = true;
+      })
+      .addCase(fetchSingleBlog.rejected, (state, action) => {
+        state.loading = false;
+        state.error = action.payload as string;
+      });
+  },
+});
+
+export default singleBlogSlice.reducer;

--- a/frontend/src/store/slices/blogs/thunks/fetchSingleBlog.ts
+++ b/frontend/src/store/slices/blogs/thunks/fetchSingleBlog.ts
@@ -1,0 +1,21 @@
+import { createAsyncThunk } from "@reduxjs/toolkit";
+import type { SingleBlog } from "@/blogs/interface/blogs";
+import { getSingleBlog } from "@/blogs/utils/getSingleBlog";
+
+export const fetchSingleBlog = createAsyncThunk<
+  SingleBlog,
+  number,
+  { rejectValue: string }
+>("fetchSingleBlog/fetchSingleBlog", async (id, thunkAPI) => {
+  try {
+    const response = await getSingleBlog(id);
+    return response;
+  } catch (error) {
+    if (error instanceof Error) {
+      return thunkAPI.rejectWithValue(
+        error.message || "Error obteniendo el blog"
+      );
+    }
+    return thunkAPI.rejectWithValue("Error desconocido");
+  }
+});

--- a/frontend/src/store/store.ts
+++ b/frontend/src/store/store.ts
@@ -7,6 +7,7 @@ import lastFiveChaptersReducer from "@/store/slices/singleBook/lastFiveChaptersS
 import getAllChaptersReducer from "@/store/slices/singleBook/getAllChaptersSlice";
 import getSingleChapterReducer from "@/store/slices/chapter/singleChapterSlice";
 import getAllBlogsReducer from "@/store/slices/blogs/allBlogsSlice";
+import singleBlogReducer from "@/store/slices/blogs/singleBlogSlice";
 
 const store = configureStore({
   reducer: {
@@ -18,6 +19,7 @@ const store = configureStore({
     getAllChaptersFromABook: getAllChaptersReducer,
     getSingleChapter: getSingleChapterReducer,
     AllBlogs: getAllBlogsReducer,
+    SingleBlog: singleBlogReducer,
   },
 });
 


### PR DESCRIPTION
This pull request includes significant updates to both the backend and frontend of the blog application, focusing on improving the retrieval and display of blog posts. The most important changes include ordering blog posts by creation date, updating the single blog post retrieval endpoint, and implementing a new component structure for displaying single blog posts on the frontend.

Backend improvements:

* [`backend/src/server/blogs/get/getAllBlogPosts.ts`](diffhunk://#diff-ec66adf24f6ff427c6bbd8705a671f5679d507d912c0d7b4be8cd35958a0dedeR9): Added ordering by `createdAt` in descending order to the `findMany` query for retrieving all blog posts.
* [`backend/src/server/blogs/get/getSingleBlogPost.ts`](diffhunk://#diff-bce412e30737473129e93a7b6849e09da63966668370e2ef0e7773b738c89ddfL16-R16): Simplified the JSON response for the single blog post retrieval endpoint.

Frontend improvements:

* `frontend/src/app/(un-auth-regular-user)/blogs/all-blogs/blog/[blogId]/page.tsx`: Replaced the existing `BlogPage` component with a new one that uses the `SingleBlog` component to display a single blog post. ([frontend/src/app/(un-auth-regular-user)/blogs/all-blogs/blog/[blogId]/page.tsxL1-R9](diffhunk://#diff-49ce21f1efe92106504b3ea150061f124b91521b2c80668edfcd415ab2b3f66cL1-R9))
* [`frontend/src/blogs/blog/singleBlog.tsx`](diffhunk://#diff-847945970529bb942f11c3afc6e185b5f791e01500768059472c10446dbc788eR1-R32): Created a new `SingleBlog` component that fetches and displays a single blog post using Redux and a loader component.
* [`frontend/src/blogs/components/SingleBlogComponent.tsx`](diffhunk://#diff-5717a5ca84bca43224c64afcfb2043fb482e797657144c155e763328c290dbc9R1-R37): Added a new `SingleBlogComponent` to render the details of a single blog post.

These changes ensure a more organized and efficient way to handle and display blog posts in the application.