### PR TITLE
Pdc 64 add other works endpoint

### DIFF
--- a/frontend/src/books/book/utils/getAllChaptersFromBook.ts
+++ b/frontend/src/books/book/utils/getAllChaptersFromBook.ts
@@ -21,7 +21,7 @@ export const getAllChaptersFromABook = async (
         year: "numeric",
       }),
     }));
-    console.log(formatedChapters);
+
     return formatedChapters;
   } catch (error) {
     console.error(error);

--- a/frontend/src/books/interfaces/bookData.d.ts
+++ b/frontend/src/books/interfaces/bookData.d.ts
@@ -4,6 +4,7 @@ export interface BookCardComponentProps {
   Synopsis: string;
   imagen: string;
   status: string;
+  bookId: number;
 }
 export interface BookProps {
   id: number;

--- a/frontend/src/books/interfaces/bookData.d.ts
+++ b/frontend/src/books/interfaces/bookData.d.ts
@@ -4,7 +4,6 @@ export interface BookCardComponentProps {
   Synopsis: string;
   imagen: string;
   status: string;
-  bookId: number;
 }
 export interface BookProps {
   id: number;

--- a/frontend/src/chapters/components/AllChaptersComponent.tsx
+++ b/frontend/src/chapters/components/AllChaptersComponent.tsx
@@ -16,10 +16,8 @@ export const AllChaptersComponent = ({ bookId }: { bookId: number }) => {
   } = useSelector((state: RootState) => state.getAllChaptersFromABook);
 
   useEffect(() => {
-    if (!chapters || chapters?.length === 0 || chapters[0].bookId !== bookId) {
-      dispatch(fetchAllChaptersFromABook(bookId));
-    }
-  }, [chapters, bookId, dispatch]);
+    dispatch(fetchAllChaptersFromABook(bookId));
+  }, [bookId, dispatch]);
 
   if (loading) {
     return (

--- a/frontend/src/chapters/components/AllChaptersComponent.tsx
+++ b/frontend/src/chapters/components/AllChaptersComponent.tsx
@@ -16,7 +16,7 @@ export const AllChaptersComponent = ({ bookId }: { bookId: number }) => {
   } = useSelector((state: RootState) => state.getAllChaptersFromABook);
 
   useEffect(() => {
-    if (chapters?.length === 0) {
+    if (!chapters || chapters?.length === 0 || chapters[0].bookId !== bookId) {
       dispatch(fetchAllChaptersFromABook(bookId));
     }
   }, [chapters, bookId, dispatch]);

--- a/frontend/src/store/slices/singleBook/thunk/fetchAllChaptersFromABook.ts
+++ b/frontend/src/store/slices/singleBook/thunk/fetchAllChaptersFromABook.ts
@@ -1,22 +1,24 @@
 import { createAsyncThunk } from "@reduxjs/toolkit";
-import { getAllChaptersFromABook } from '../../../../books/book/utils/getAllChaptersFromBook';
+import { getAllChaptersFromABook } from "../../../../books/book/utils/getAllChaptersFromBook";
 import { Chapter } from "@/books/interfaces/bookData";
 
 export const fetchAllChaptersFromABook = createAsyncThunk<
-Chapter[],
-number,
-{rejectValue: string}>("fetchAllChaptersFromABook/fetchAllChaptersFromABook", 
-    async(bookId, thunkAPI) =>{
-        try{
-            const response = await getAllChaptersFromABook(bookId)
-            return response
-        }catch(error){
-            if( error instanceof Error){
-                return thunkAPI.rejectWithValue(
-                    error.message ||"Error obteniendo los capítulos del libro"
-                )
-            }
-            return thunkAPI.rejectWithValue("Error desconocido")
-        }
+  Chapter[],
+  number,
+  { rejectValue: string }
+>(
+  "fetchAllChaptersFromABook/fetchAllChaptersFromABook",
+  async (bookId, thunkAPI) => {
+    try {
+      const response = await getAllChaptersFromABook(bookId);
+      return response;
+    } catch (error) {
+      if (error instanceof Error) {
+        return thunkAPI.rejectWithValue(
+          error.message || "Error obteniendo los capítulos del libro"
+        );
+      }
+      return thunkAPI.rejectWithValue("Error desconocido");
     }
-)
+  }
+);


### PR DESCRIPTION
This pull request includes several changes to the `frontend` codebase, focusing on improving code readability and removing unnecessary code. The most important changes include removing a console log statement, fixing a condition in a useEffect hook, and formatting code in a thunk file.

Code readability improvements:

* [`frontend/src/books/book/utils/getAllChaptersFromBook.ts`](diffhunk://#diff-90856ed148b91f29221e0f42b91418c21ac6f404b0aae5ae707945b63fd9c247L24-R24): Removed a console log statement that was used for debugging purposes.

Code cleanup:

* [`frontend/src/chapters/components/AllChaptersComponent.tsx`](diffhunk://#diff-7b05438e35968629a8d44212fe3e30daca03418f6ac1062e89994e9d05f5eadeL19-R20): Fixed the condition in the useEffect hook by removing the check for `chapters?.length === 0`, ensuring the dispatch function is called whenever `bookId` or `dispatch` changes.
* [`frontend/src/store/slices/singleBook/thunk/fetchAllChaptersFromABook.ts`](diffhunk://#diff-b0ba5bf1d28963a4e45c15ffcb7b8186d78a5e457af33c1231c81e0dc35150c7L2-R24): Reformatted the code to improve readability, including fixing indentation and adding semicolons.