### PR TITLE
fix: add "Crear otro trabajo" button to empty other works state

### DIFF
--- a/frontend/src/other-works/components/OtherWorkAdminPageContainer.tsx
+++ b/frontend/src/other-works/components/OtherWorkAdminPageContainer.tsx
@@ -34,6 +34,10 @@ export const OtherWorkAdminPageContainer = () => {
   if (!otherWorks || otherWorks.length === 0) {
     return (
       <div className="flex items-center justify-center h-screen">
+        <MainButton
+          link="/admin/otros-trabajos/crear"
+          name="Crear otro trabajo"
+        />
         <h1 className="text-2xl text-gray-500">
           No hay otros trabajos disponibles
         </h1>


### PR DESCRIPTION
This pull request introduces a small enhancement to the `OtherWorkAdminPageContainer` component. The change adds a `MainButton` that allows users to navigate to the "Create Other Work" page when no other works are available.