### PR TITLE
fix: replace Image component with ImageComponent in OtherWorksCard an…

### DIFF
--- a/frontend/src/homepage/other-works/OtherWorkCard.tsx
+++ b/frontend/src/homepage/other-works/OtherWorkCard.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import type { OtherWorkComponentProps } from "./interface/other-works-interface";
 import MainButton from "@/components/shared/mainButton";
 import Image from "next/image";
+import { ImageComponent } from "@/components/shared/ImageComponent";
 
 const OtherWorksCard: React.FC<OtherWorkComponentProps> = ({
   title,
@@ -29,13 +30,7 @@ const OtherWorksCard: React.FC<OtherWorkComponentProps> = ({
         </div>
       </div>
       <div className="flex w-full h-full items-center justify-center mlg:justify-end">
-        <Image
-          src={imagen}
-          alt={title}
-          width={300}
-          height={300}
-          className="rounded-xl"
-        />
+        <ImageComponent imagen={imagen} title={title} />
       </div>
     </div>
   );

--- a/frontend/src/homepage/other-works/slideshow/DesktopSlideshow.tsx
+++ b/frontend/src/homepage/other-works/slideshow/DesktopSlideshow.tsx
@@ -63,7 +63,7 @@ export const DesktopSlideshow = ({ otherWorks, className }: Props) => {
         className="mySwiper transition-all duration-500 ease-in-out"
       >
         {otherWorks.map((otherWork) => (
-          <SwiperSlide key={otherWork.id}>
+          <SwiperSlide key={otherWork.id} className="!h-full">
             <OtherWorkCard
               id={otherWork.id}
               title={otherWork.title}


### PR DESCRIPTION
This pull request introduces changes to improve the rendering of images and enhance the layout consistency in the `OtherWorksCard` and `DesktopSlideshow` components. The most important updates include replacing the `Image` component with a custom `ImageComponent` and adding a class for consistent height in `SwiperSlide`.

### Image Rendering Improvements:
* [`frontend/src/homepage/other-works/OtherWorkCard.tsx`](diffhunk://#diff-bef9083b979479f7a39ac44bd5bdd034e2695be1671832f654cdab859cc45b27L32-R33): Replaced the `Image` component with a custom `ImageComponent` to handle image rendering, improving flexibility and maintainability.
* [`frontend/src/homepage/other-works/OtherWorkCard.tsx`](diffhunk://#diff-bef9083b979479f7a39ac44bd5bdd034e2695be1671832f654cdab859cc45b27R5): Imported `ImageComponent` from the shared components directory to support the new image rendering approach.

### Layout Enhancements:
* [`frontend/src/homepage/other-works/slideshow/DesktopSlideshow.tsx`](diffhunk://#diff-54fe5a774c17d92412b1d8fc17c1f936232ab25a8fc18b41b6097a6f70b0be34L66-R66): Added a `!h-full` class to `SwiperSlide` to ensure consistent height across slides in the slideshow component.…d add full height to SwiperSlide in DesktopSlideshow